### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,10 +21,10 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
-        <springdoc.version>1.6.9</springdoc.version>
+        <org.mapstruct.version> 1.6.3</org.mapstruct.version>
+        <springdoc.version>1.6.11</springdoc.version>
         <junit>4.12</junit>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
     </properties>
 
     <parent>
@@ -88,9 +88,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>21.3.0.0</version>
         </dependency>
         <!--grad-releaseGRAD2-1899 Upgarding API to Spring Boot 3.0.2-->
         <dependency>
@@ -194,7 +194,7 @@
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>
           <artifactId>hibernate-enhance-maven-plugin</artifactId>
-          <version>6.1.1.Final</version>
+          <version>6.6.4.Final</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
@@ -278,7 +278,7 @@
           <plugin>
             <groupId>org.hibernate.orm.tooling</groupId>
             <artifactId>hibernate-enhance-maven-plugin</artifactId>
-            <version>6.1.1.Final</version>
+            <version>6.6.4.Final</version>
             <executions>
               <execution>
                 <configuration>


### PR DESCRIPTION
Change Details:

- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.5.Final  [Used 6.6.4.Final ]
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3 
- Bump actions/setup-java from 1 to 4 
- Bump log4j.version from 2.18.0 to 2.19.0   [Used 2.20.0]
- Bump springdoc.version from 1.6.9 to 1.6.11 
- Upgrade ojdbc8 to ojdbc11